### PR TITLE
7x7 grids and torus topology

### DIFF
--- a/find-optimal/CMakeLists.txt
+++ b/find-optimal/CMakeLists.txt
@@ -197,7 +197,6 @@ set_target_properties(find-optimal-torus PROPERTIES
 
 # Additional executables
 add_executable(explore-subgrid src/explore-subgrid.cpp)
-add_executable(explore-reversibility src/explore-reversibility.cpp)
 add_executable(validate-frame-search-completeness src/validate_frame_search_completeness.cpp)
 
 # Hash function comparison tool

--- a/find-optimal/CMakeLists.txt
+++ b/find-optimal/CMakeLists.txt
@@ -197,6 +197,7 @@ set_target_properties(find-optimal-torus PROPERTIES
 
 # Additional executables
 add_executable(explore-subgrid src/explore-subgrid.cpp)
+add_executable(explore-reversibility src/explore-reversibility.cpp)
 add_executable(validate-frame-search-completeness src/validate_frame_search_completeness.cpp)
 
 # Hash function comparison tool

--- a/find-optimal/include/cli_parser.h
+++ b/find-optimal/include/cli_parser.h
@@ -26,6 +26,11 @@ enum SimulateType {
   SIMULATE_NONE
 };
 
+enum GridSize {
+  GRID_SIZE_8X8,
+  GRID_SIZE_7X7
+};
+
 typedef struct ProgramArgs {
   bool resumeFromDatabase;
   bool compareCycleAlgorithms;
@@ -36,7 +41,10 @@ typedef struct ProgramArgs {
   TestApiType testApi;
   SimulateType simulateType;
   FrameMode frameMode;
+  GridSize gridSize;
   uint64_t frameModeIndex;  // Only used when frameMode == FRAME_MODE_INDEX
+  uint64_t grid7x7StartPattern;  // Starting pattern for 7x7 search (default: 0)
+  uint64_t grid7x7EndPattern;    // Ending pattern for 7x7 search (default: 2^49 - 1)
   std::string logFilePath;
   std::string queueDirectory;
   std::string subgridCachePath;

--- a/find-optimal/include/display_utils.h
+++ b/find-optimal/include/display_utils.h
@@ -7,25 +7,37 @@
 #include <string>
 #include <iomanip>
 
-// Convert a 64-bit number to its binary string representation
+// Convert a number to its binary string representation
+// numBits: number of bits to output (e.g., 64 for 8x8, 49 for 7x7)
+// Note: Buffer must be at least (numBits + 1) bytes to hold result + null terminator
 constexpr int BINARY_STRING_SIZE = 65;
+constexpr int BINARY_STRING_MAX_BITS = 64;
 
-static inline void asBinary(uint64_t number, char *buf) {
-  for (int i = 0; i < 64; ++i) {
-    buf[i] = (number >> (63 - i)) & 1 ? '1' : '0';
+static inline void asBinary(uint64_t number, char *buf, int numBits = 64) {
+  // Validate arguments to prevent buffer overflow
+  if (numBits < 0 || numBits > BINARY_STRING_MAX_BITS) {
+    // Invalid numBits - write error marker and return
+    buf[0] = '?';
+    buf[1] = '\0';
+    return;
   }
-  buf[64] = '\0';  // Ensure null termination
+
+  for (int i = 0; i < numBits; ++i) {
+    buf[i] = (number >> (numBits - 1 - i)) & 1 ? '1' : '0';
+  }
+  buf[numBits] = '\0';  // Ensure null termination
 }
 
 
-// Print a 64-bit pattern as an 8x8 grid with compact formatting (. for 0, single space)
-static inline void printPattern(uint64_t number) {
-  for (int row = 0; row < 8; row++) {
-    for (int col = 0; col < 8; col++) {
-      int bitPos = row * 8 + col;
+// Print a pattern with configurable grid size (compact format: gridSize consecutive bits per row)
+// gridSize: 7 for 7x7 grid, 8 for 8x8 grid (default)
+static inline void printPattern(uint64_t number, int gridSize = 8) {
+  for (int row = 0; row < gridSize; row++) {
+    for (int col = 0; col < gridSize; col++) {
+      int bitPos = row * gridSize + col;
       char bit = (number & (1ULL << bitPos)) ? '1' : '.';
       std::cout << bit;
-      if (col < 7) std::cout << " ";
+      if (col < gridSize - 1) std::cout << " ";
     }
     std::cout << "\n";
   }

--- a/find-optimal/include/gol.h
+++ b/find-optimal/include/gol.h
@@ -41,8 +41,11 @@ __host__ void *search(void *args);
 
 // Search execution functions (using RAII memory management)
 __host__ void executeKernelSearch(gol::SearchMemory &mem, ProgramArgs *cli, uint64_t frame, uint64_t frameIdx);
+__host__ void execute7x7Search(gol::SearchMemory &mem, ProgramArgs *cli, uint64_t rangeStart, uint64_t rangeEnd);
 __host__ void reportKernelResults(gol::SearchMemory &mem, ProgramArgs *cli, double startTime, uint64_t frame,
                                   uint64_t frameIdx, int kernelIdx, bool isFrameComplete);
+__host__ void report7x7Results(gol::SearchMemory &mem, ProgramArgs *cli, double startTime,
+                                uint64_t rangeStart, uint64_t rangeEnd);
 
 // Helper functions
 __host__ std::string getSearchDescription(ProgramArgs *cli);

--- a/find-optimal/include/gol_core.h
+++ b/find-optimal/include/gol_core.h
@@ -383,7 +383,6 @@ __host__ __device__ static inline uint64_t computeNextGeneration7x7(uint64_t com
 // ============================================================================
 // 8x8 Grid Helper - Expand 7x7 pattern to specific position on 8x8 grid
 // ============================================================================
-// This is for the OLD approach of testing 4 positions on 8x8
 // Expand a compact 7x7 pattern (7 bits/row) to 8x8 grid format (8 bits/row) at given position
 // pattern7x7: compact format with 7 consecutive bits per row (49 bits total)
 // rowOffset: 0 for rows 0-6, 1 for rows 1-7

--- a/find-optimal/include/gol_core.h
+++ b/find-optimal/include/gol_core.h
@@ -198,12 +198,15 @@ __host__ __device__ static inline uint64_t computeNextGeneration8x8(uint64_t a) 
   return computeNextGeneration(a, shiftLeft8x8, shiftRight8x8, shiftUp8x8, shiftDown8x8);
 }
 
+// 7x7 unpacked format valid bits mask (bits 0-6 of each byte, 7 rows only - byte 8 should be 0)
+#define GOL_7X7_UNPACKED_MASK 0x007F7F7F7F7F7F7FULL
+
 // 7x7 next generation computation using Rokicki's algorithm adapted for 7x7
 // Works for both torus and plane topologies (determined by shift functions above)
-__host__ __device__ static inline uint64_t computeNextGeneration7x7(uint64_t compact7x7) {
-  uint64_t a = unpack7x7(compact7x7);
-  uint64_t result = computeNextGeneration(a, shiftLeft7x7, shiftRight7x7, shiftUp7x7, shiftDown7x7);
-  return pack7x7(result);
+// Input and output are in unpacked format (byte-aligned: 7 bits per byte, 7 rows)
+__host__ __device__ static inline uint64_t computeNextGeneration7x7(uint64_t unpacked7x7) {
+  uint64_t result = computeNextGeneration(unpacked7x7, shiftLeft7x7, shiftRight7x7, shiftUp7x7, shiftDown7x7);
+  return result & GOL_7X7_UNPACKED_MASK;  // Mask to ensure only valid 7x7 bits are set
 }
 
 __host__ __device__ static inline int adjustGenerationsForDeadout(int generations, uint64_t g2, uint64_t g3,

--- a/find-optimal/include/gol_core.h
+++ b/find-optimal/include/gol_core.h
@@ -15,12 +15,22 @@
 #endif
 
 // Conway's Game of Life bit manipulation masks - 8x8 grid
-#define GOL_HORIZONTAL_SHIFT_MASK 0x7f7f7f7f7f7f7f7f
-#define GOL_VERTICAL_SHIFT_MASK 0xFEFEFEFEFEFEFEFE
+#define GOL_8X8_HORIZONTAL_SHIFT_MASK 0x7F7F7F7F7F7F7F7FULL  // Bits 0-6 in each byte
+#define GOL_8X8_VERTICAL_SHIFT_MASK   0xFEFEFEFEFEFEFEFEULL  // Bits 1-7 in each byte
+#define GOL_8X8_LEFT_EDGE_MASK        0x8080808080808080ULL  // Bit 7 in each byte (left edge)
+#define GOL_8X8_RIGHT_EDGE_MASK       0x0101010101010101ULL  // Bit 0 in each byte (right edge)
 
 // 7x7 grid masks (byte-aligned format: 7 bits per byte, 7 rows)
 #define GOL_7X7_HORIZONTAL_SHIFT_MASK 0x3F3F3F3F3F3F3F3FULL  // Bits 0-5 in each byte
 #define GOL_7X7_VERTICAL_SHIFT_MASK   0x7E7E7E7E7E7E7E7EULL  // Bits 1-6 in each byte
+#define GOL_7X7_LEFT_EDGE_MASK        0x4040404040404040ULL  // Bit 6 in each byte (left edge)
+#define GOL_7X7_RIGHT_EDGE_MASK       0x0101010101010101ULL  // Bit 0 in each byte (right edge)
+
+// 7x7 subgrid position masks for coverage testing on 8x8 grid
+#define GOL_7X7_POSITION_0_MASK       0x7F7F7F7F7F7F7FULL    // Rows 0-6, cols 0-6
+#define GOL_7X7_POSITION_1_MASK       0xFEFEFEFEFEFEFEULL    // Rows 0-6, cols 1-7
+#define GOL_7X7_POSITION_2_MASK       0x7F7F7F7F7F7F7F00ULL  // Rows 1-7, cols 0-6
+#define GOL_7X7_POSITION_3_MASK       0xFEFEFEFEFEFEFE00ULL  // Rows 1-7, cols 1-7
 
 // Generation counting constants
 #define MIN_CANDIDATE_GENERATIONS 180
@@ -40,64 +50,161 @@ __host__ __device__ static inline void add3(uint64_t a, uint64_t b, uint64_t c, 
   s1 = t1 ^ t2;
 }
 
+// ============================================================================
+// Grid Shift Operations - 8x8 and 7x7
+// ============================================================================
 // Tom Rokicki's optimized 19-operation Conway's Game of Life computation
 // Topology selection: define TOPOLOGY_TORUS at compile time for wrapping boundaries
 // Default (no flag): box/plane topology with non-wrapping boundaries
 
+// Helper: Unpack compact 7x7 to byte-aligned format for easier bit manipulation
+// Converts: row at (7*n) bit offset → row at (8*n) bit offset (byte-aligned)
+__host__ __device__ static inline uint64_t unpack7x7(uint64_t compact) {
+  uint64_t result = 0;
+  result |= ((compact >>  0) & 0x7F) <<  0;  // Row 0: bits 0-6 → bits 0-6
+  result |= ((compact >>  7) & 0x7F) <<  8;  // Row 1: bits 7-13 → bits 8-14
+  result |= ((compact >> 14) & 0x7F) << 16;  // Row 2: bits 14-20 → bits 16-22
+  result |= ((compact >> 21) & 0x7F) << 24;  // Row 3: bits 21-27 → bits 24-30
+  result |= ((compact >> 28) & 0x7F) << 32;  // Row 4: bits 28-34 → bits 32-38
+  result |= ((compact >> 35) & 0x7F) << 40;  // Row 5: bits 35-41 → bits 40-46
+  result |= ((compact >> 42) & 0x7F) << 48;  // Row 6: bits 42-48 → bits 48-54
+  return result;
+}
+
+// Helper: Pack byte-aligned format back to compact 7x7
+__host__ __device__ static inline uint64_t pack7x7(uint64_t unpacked) {
+  uint64_t result = 0;
+  result |= ((unpacked >>  0) & 0x7F) <<  0;  // Row 0: bits 0-6 → bits 0-6
+  result |= ((unpacked >>  8) & 0x7F) <<  7;  // Row 1: bits 8-14 → bits 7-13
+  result |= ((unpacked >> 16) & 0x7F) << 14;  // Row 2: bits 16-22 → bits 14-20
+  result |= ((unpacked >> 24) & 0x7F) << 21;  // Row 3: bits 24-30 → bits 21-27
+  result |= ((unpacked >> 32) & 0x7F) << 28;  // Row 4: bits 32-38 → bits 28-34
+  result |= ((unpacked >> 40) & 0x7F) << 35;  // Row 5: bits 40-46 → bits 35-41
+  result |= ((unpacked >> 48) & 0x7F) << 42;  // Row 6: bits 48-54 → bits 42-48
+  return result;
+}
+
 #ifdef TOPOLOGY_TORUS
 
-// Circular shift helpers for torus topology (wrapping boundaries)
-__host__ __device__ static inline uint64_t circularShiftLeft(uint64_t a) {
-  uint64_t shifted = (a & 0x7F7F7F7F7F7F7F7FULL) << 1;
-  uint64_t wrapped = (a & 0x8080808080808080ULL) >> 7;
+// Circular shift helpers for torus topology (wrapping boundaries) - 8x8 grid
+__host__ __device__ static inline uint64_t shiftLeft8x8(uint64_t a) {
+  uint64_t shifted = (a & GOL_8X8_HORIZONTAL_SHIFT_MASK) << 1;
+  uint64_t wrapped = (a & GOL_8X8_LEFT_EDGE_MASK) >> 7;
   return shifted | wrapped;
 }
 
-__host__ __device__ static inline uint64_t circularShiftRight(uint64_t a) {
-  uint64_t shifted = (a & 0xFEFEFEFEFEFEFEFEULL) >> 1;
-  uint64_t wrapped = (a & 0x0101010101010101ULL) << 7;
+__host__ __device__ static inline uint64_t shiftRight8x8(uint64_t a) {
+  uint64_t shifted = (a & GOL_8X8_VERTICAL_SHIFT_MASK) >> 1;
+  uint64_t wrapped = (a & GOL_8X8_RIGHT_EDGE_MASK) << 7;
   return shifted | wrapped;
 }
 
-__host__ __device__ static inline uint64_t circularShiftUp(uint64_t a) {
+__host__ __device__ static inline uint64_t shiftUp8x8(uint64_t a) {
   uint64_t shifted = a << 8;
-  uint64_t wrapped = (a >> 56) & 0xFF;
+  uint64_t wrapped = (a >> 56) & 0xFFULL;
   return shifted | wrapped;
 }
 
-__host__ __device__ static inline uint64_t circularShiftDown(uint64_t a) {
+__host__ __device__ static inline uint64_t shiftDown8x8(uint64_t a) {
   uint64_t shifted = a >> 8;
-  uint64_t wrapped = (a & 0xFF) << 56;
+  uint64_t wrapped = (a & 0xFFULL) << 56;
   return shifted | wrapped;
 }
 
-// Torus implementation with circular shifts for wrapping (8x8 grid)
-__host__ __device__ static inline uint64_t computeNextGeneration8x8(uint64_t a) {
-  uint64_t s0, sh2, a0, a1, sll, slh;
-  add2(circularShiftLeft(a), circularShiftRight(a), s0, sh2);
-  add2(s0, a, a0, a1);
-  a1 |= sh2;
-  add3(circularShiftDown(a0), circularShiftUp(a0), s0, sll, slh);
-  uint64_t y = circularShiftDown(a1);
-  uint64_t x = circularShiftUp(a1);
-  return (x ^ y ^ sh2 ^ slh) & ((x | y) ^ (sh2 | slh)) & (sll | a);
+// Circular shift helpers for torus topology (wrapping boundaries) - 7x7 grid
+__host__ __device__ static inline uint64_t shiftLeft7x7(uint64_t a) {
+  uint64_t shifted = (a & GOL_7X7_HORIZONTAL_SHIFT_MASK) << 1;
+  uint64_t wrapped = (a & GOL_7X7_LEFT_EDGE_MASK) >> 6;
+  return shifted | wrapped;
+}
+
+__host__ __device__ static inline uint64_t shiftRight7x7(uint64_t a) {
+  uint64_t shifted = (a & GOL_7X7_VERTICAL_SHIFT_MASK) >> 1;
+  uint64_t wrapped = (a & GOL_7X7_RIGHT_EDGE_MASK) << 6;
+  return shifted | wrapped;
+}
+
+__host__ __device__ static inline uint64_t shiftUp7x7(uint64_t a) {
+  uint64_t shifted = a << 8;
+  uint64_t wrapped = (a >> 48) & 0x7FULL;
+  return shifted | wrapped;
+}
+
+__host__ __device__ static inline uint64_t shiftDown7x7(uint64_t a) {
+  uint64_t shifted = a >> 8;
+  uint64_t wrapped = (a & 0x7FULL) << 48;
+  return shifted | wrapped;
 }
 
 #else
 
-// Box/plane implementation with masked shifts for non-wrapping boundaries (8x8 grid)
-__host__ __device__ static inline uint64_t computeNextGeneration8x8(uint64_t a) {
-  uint64_t s0, sh2, a0, a1, sll, slh;
-  add2((a & GOL_HORIZONTAL_SHIFT_MASK) << 1, (a & GOL_VERTICAL_SHIFT_MASK) >> 1, s0, sh2);
-  add2(s0, a, a0, a1);
-  a1 |= sh2;
-  add3(a0 >> 8, a0 << 8, s0, sll, slh);
-  uint64_t y = a1 >> 8;
-  uint64_t x = a1 << 8;
-  return (x ^ y ^ sh2 ^ slh) & ((x | y) ^ (sh2 | slh)) & (sll | a);
+// Box/plane shift helpers for non-wrapping boundaries - 8x8 grid
+__host__ __device__ static inline uint64_t shiftLeft8x8(uint64_t a) {
+  return (a & GOL_8X8_HORIZONTAL_SHIFT_MASK) << 1;
+}
+
+__host__ __device__ static inline uint64_t shiftRight8x8(uint64_t a) {
+  return (a & GOL_8X8_VERTICAL_SHIFT_MASK) >> 1;
+}
+
+__host__ __device__ static inline uint64_t shiftUp8x8(uint64_t a) {
+  return a << 8;
+}
+
+__host__ __device__ static inline uint64_t shiftDown8x8(uint64_t a) {
+  return a >> 8;
+}
+
+// Box/plane shift helpers for non-wrapping boundaries - 7x7 grid
+__host__ __device__ static inline uint64_t shiftLeft7x7(uint64_t a) {
+  return (a & GOL_7X7_HORIZONTAL_SHIFT_MASK) << 1;
+}
+
+__host__ __device__ static inline uint64_t shiftRight7x7(uint64_t a) {
+  return (a & GOL_7X7_VERTICAL_SHIFT_MASK) >> 1;
+}
+
+__host__ __device__ static inline uint64_t shiftUp7x7(uint64_t a) {
+  return a << 8;
+}
+
+__host__ __device__ static inline uint64_t shiftDown7x7(uint64_t a) {
+  return a >> 8;
 }
 
 #endif
+
+// Generic template for computing next generation using Rokicki's algorithm
+// Works with any set of shift functions (8x8 or 7x7, torus or plane)
+template<typename ShiftLeft, typename ShiftRight, typename ShiftUp, typename ShiftDown>
+__host__ __device__ static inline uint64_t computeNextGeneration(
+    uint64_t a,
+    ShiftLeft shiftLeft,
+    ShiftRight shiftRight,
+    ShiftUp shiftUp,
+    ShiftDown shiftDown) {
+  uint64_t s0, sh2, a0, a1, sll, slh;
+  add2(shiftLeft(a), shiftRight(a), s0, sh2);
+  add2(s0, a, a0, a1);
+  a1 |= sh2;
+  add3(shiftDown(a0), shiftUp(a0), s0, sll, slh);
+  uint64_t y = shiftDown(a1);
+  uint64_t x = shiftUp(a1);
+  return (x ^ y ^ sh2 ^ slh) & ((x | y) ^ (sh2 | slh)) & (sll | a);
+}
+
+// 8x8 next generation computation
+__host__ __device__ static inline uint64_t computeNextGeneration8x8(uint64_t a) {
+  return computeNextGeneration(a, shiftLeft8x8, shiftRight8x8, shiftUp8x8, shiftDown8x8);
+}
+
+// 7x7 next generation computation using Rokicki's algorithm adapted for 7x7
+// Works for both torus and plane topologies (determined by shift functions above)
+__host__ __device__ static inline uint64_t computeNextGeneration7x7(uint64_t compact7x7) {
+  uint64_t a = unpack7x7(compact7x7);
+  uint64_t result = computeNextGeneration(a, shiftLeft7x7, shiftRight7x7, shiftUp7x7, shiftDown7x7);
+  return pack7x7(result);
+}
 
 __host__ __device__ static inline int adjustGenerationsForDeadout(int generations, uint64_t g2, uint64_t g3,
                                                                   uint64_t g4, uint64_t g5, uint64_t g6) {
@@ -276,111 +383,6 @@ __host__ __device__ static inline uint64_t getNextCandidateIndex(uint64_t* numCa
 }
 
 // ============================================================================
-// 7x7 Grid Simulation - Direct simulation on compact 7x7 format
-// ============================================================================
-// 7x7 patterns use compact storage: 7 consecutive bits per row (49 bits total)
-// Layout: row0[bits 0-6] | row1[bits 7-13] | ... | row6[bits 42-48]
-//
-// This is different from simulating 7x7 placed on 8x8, because boundary
-// conditions differ - a true 7x7 grid has 7-column wrap/boundary behavior
-
-// Helper: Unpack compact 7x7 to byte-aligned format for easier bit manipulation
-// Converts: row at (7*n) bit offset → row at (8*n) bit offset (byte-aligned)
-__host__ __device__ static inline uint64_t unpack7x7(uint64_t compact) {
-  uint64_t result = 0;
-  result |= ((compact >>  0) & 0x7F) <<  0;  // Row 0: bits 0-6 → bits 0-6
-  result |= ((compact >>  7) & 0x7F) <<  8;  // Row 1: bits 7-13 → bits 8-14
-  result |= ((compact >> 14) & 0x7F) << 16;  // Row 2: bits 14-20 → bits 16-22
-  result |= ((compact >> 21) & 0x7F) << 24;  // Row 3: bits 21-27 → bits 24-30
-  result |= ((compact >> 28) & 0x7F) << 32;  // Row 4: bits 28-34 → bits 32-38
-  result |= ((compact >> 35) & 0x7F) << 40;  // Row 5: bits 35-41 → bits 40-46
-  result |= ((compact >> 42) & 0x7F) << 48;  // Row 6: bits 42-48 → bits 48-54
-  return result;
-}
-
-// Helper: Pack byte-aligned format back to compact 7x7
-__host__ __device__ static inline uint64_t pack7x7(uint64_t unpacked) {
-  uint64_t result = 0;
-  result |= ((unpacked >>  0) & 0x7F) <<  0;  // Row 0: bits 0-6 → bits 0-6
-  result |= ((unpacked >>  8) & 0x7F) <<  7;  // Row 1: bits 8-14 → bits 7-13
-  result |= ((unpacked >> 16) & 0x7F) << 14;  // Row 2: bits 16-22 → bits 14-20
-  result |= ((unpacked >> 24) & 0x7F) << 21;  // Row 3: bits 24-30 → bits 21-27
-  result |= ((unpacked >> 32) & 0x7F) << 28;  // Row 4: bits 32-38 → bits 28-34
-  result |= ((unpacked >> 40) & 0x7F) << 35;  // Row 5: bits 40-46 → bits 35-41
-  result |= ((unpacked >> 48) & 0x7F) << 42;  // Row 6: bits 48-54 → bits 42-48
-  return result;
-}
-
-#ifdef TOPOLOGY_TORUS
-
-// 7x7 torus topology: circular shifts with 7-column wrapping
-__host__ __device__ static inline uint64_t shiftLeft7x7(uint64_t a) {
-  // Shift each byte left by 1, wrapping bit 6 to bit 0
-  uint64_t shifted = (a & GOL_7X7_HORIZONTAL_SHIFT_MASK) << 1;  // Bits 0-5 shift left
-  uint64_t wrapped = (a & 0x4040404040404040ULL) >> 6;          // Bit 6 wraps to bit 0
-  return shifted | wrapped;
-}
-
-__host__ __device__ static inline uint64_t shiftRight7x7(uint64_t a) {
-  // Shift each byte right by 1, wrapping bit 0 to bit 6
-  uint64_t shifted = (a & GOL_7X7_VERTICAL_SHIFT_MASK) >> 1;  // Bits 1-6 shift right
-  uint64_t wrapped = (a & 0x0101010101010101ULL) << 6;        // Bit 0 wraps to bit 6
-  return shifted | wrapped;
-}
-
-__host__ __device__ static inline uint64_t shiftUp7x7(uint64_t a) {
-  // Shift up by one row (shift bits up by 8), wrap row 6 to row 0
-  uint64_t shifted = a << 8;
-  uint64_t wrapped = (a >> 48) & 0x7F;  // Row 6 wraps to row 0
-  return shifted | wrapped;
-}
-
-__host__ __device__ static inline uint64_t shiftDown7x7(uint64_t a) {
-  // Shift down by one row (shift bits down by 8), wrap row 0 to row 6
-  uint64_t shifted = a >> 8;
-  uint64_t wrapped = (a & 0x7F) << 48;  // Row 0 wraps to row 6
-  return shifted | wrapped;
-}
-
-#else
-
-// 7x7 plane/box topology: masked shifts with 7-column boundaries (no wrapping)
-__host__ __device__ static inline uint64_t shiftLeft7x7(uint64_t a) {
-  return (a & GOL_7X7_HORIZONTAL_SHIFT_MASK) << 1;
-}
-
-__host__ __device__ static inline uint64_t shiftRight7x7(uint64_t a) {
-  return (a & GOL_7X7_VERTICAL_SHIFT_MASK) >> 1;
-}
-
-__host__ __device__ static inline uint64_t shiftUp7x7(uint64_t a) {
-  return a << 8;  // No wrapping, cells in row 7+ are always dead
-}
-
-__host__ __device__ static inline uint64_t shiftDown7x7(uint64_t a) {
-  return a >> 8;  // No wrapping, cells in row -1 are always dead
-}
-
-#endif
-
-// 7x7 next generation computation using Rokicki's algorithm adapted for 7x7
-// Works for both torus and plane topologies (determined by shift functions above)
-__host__ __device__ static inline uint64_t computeNextGeneration7x7(uint64_t compact7x7) {
-  uint64_t a = unpack7x7(compact7x7);
-
-  uint64_t s0, sh2, a0, a1, sll, slh;
-  add2(shiftLeft7x7(a), shiftRight7x7(a), s0, sh2);
-  add2(s0, a, a0, a1);
-  a1 |= sh2;
-  add3(shiftDown7x7(a0), shiftUp7x7(a0), s0, sll, slh);
-  uint64_t y = shiftDown7x7(a1);
-  uint64_t x = shiftUp7x7(a1);
-  uint64_t result = (x ^ y ^ sh2 ^ slh) & ((x | y) ^ (sh2 | slh)) & (sll | a);
-
-  return pack7x7(result);
-}
-
-// ============================================================================
 // 8x8 Grid Helper - Expand 7x7 pattern to specific position on 8x8 grid
 // ============================================================================
 // Expand a compact 7x7 pattern (7 bits/row) to 8x8 grid format (8 bits/row) at given position
@@ -407,15 +409,11 @@ __host__ __device__ static inline uint64_t expand7x7To8x8(uint64_t pattern7x7, i
 __host__ __device__ static inline bool isCoverableBy7x7(uint64_t pattern) {
   if (pattern == 0) return false;
 
-  // Test 4 possible 7x7 positions within the 8x8 grid:
-  // Position 1: rows 0-6, cols 0-6
-  if ((pattern & ~0x7F7F7F7F7F7F7FULL) == 0) return true;
-  // Position 2: rows 0-6, cols 1-7
-  if ((pattern & ~0xFEFEFEFEFEFEFEULL) == 0) return true;
-  // Position 3: rows 1-7, cols 0-6
-  if ((pattern & ~0x7F7F7F7F7F7F7F00ULL) == 0) return true;
-  // Position 4: rows 1-7, cols 1-7
-  if ((pattern & ~0xFEFEFEFEFEFEFE00ULL) == 0) return true;
+  // Test 4 possible 7x7 positions within the 8x8 grid
+  if ((pattern & ~GOL_7X7_POSITION_0_MASK) == 0) return true;
+  if ((pattern & ~GOL_7X7_POSITION_1_MASK) == 0) return true;
+  if ((pattern & ~GOL_7X7_POSITION_2_MASK) == 0) return true;
+  if ((pattern & ~GOL_7X7_POSITION_3_MASK) == 0) return true;
 
   return false;
 }

--- a/find-optimal/src/cli_parser.cpp
+++ b/find-optimal/src/cli_parser.cpp
@@ -23,8 +23,9 @@ static char ProgramArgs_doc[] = "";
 // Command line options
 static struct argp_option argp_options[] = {
     {"frame-mode", 'f', "MODE", 0, "Frame search mode: 'random', 'sequential', or 'index:XXXXX' (single frame by index)"},
+    {"7x7-mode", '7', "RANGE", OPTION_ARG_OPTIONAL, "Search 7x7 grid: 'start:end', ':end' (from 1), 'start:' (to 2^49), or omit for full search"},
     {"cycle-detection", 'D', "ALGORITHM", 0, "Cycle detection algorithm: 'floyd' or 'nivasch' (default: 'floyd')"},
-    {"simulate", 's', "TYPE", 0, "Simulate mode: 'pattern' (evolution) or 'symmetry' (transformations)."},
+    {"simulate", 's', "TYPE", 0, "Simulate mode: 'pattern' (8x8 evolution), 'pattern:7x7' (7x7 evolution), or 'symmetry' (transformations)."},
     {"compare-cycle-algorithms", 'A', "FRAME_IDX", 0,
      "Compare Floyd's vs Nivasch's cycle detection on given frame index and exit."},
     {"compute-subgrid-cache", 'c', "PATH", 0, "Compute 7x7 subgrid cache for all 2^49 patterns and save to disk at PATH."},
@@ -101,13 +102,18 @@ static bool parseSimulateType(const char* arg, ProgramArgs* args) {
 
   if (str == "pattern") {
     args->simulateType = SIMULATE_PATTERN;
+    args->gridSize = GRID_SIZE_8X8;
+    return true;
+  } else if (str == "pattern:7x7") {
+    args->simulateType = SIMULATE_PATTERN;
+    args->gridSize = GRID_SIZE_7X7;
     return true;
   } else if (str == "symmetry") {
     args->simulateType = SIMULATE_SYMMETRY;
     return true;
   }
 
-  std::cerr << "[ERROR] Invalid simulate type '" << arg << "', expected 'pattern' or 'symmetry'\n";
+  std::cerr << "[ERROR] Invalid simulate type '" << arg << "', expected 'pattern', 'pattern:7x7', or 'symmetry'\n";
   return false;
 }
 
@@ -159,6 +165,65 @@ static bool parseTestApi(const char* arg, ProgramArgs* args) {
   return false;
 }
 
+static bool parse7x7Range(const char* arg, ProgramArgs* args) {
+  const uint64_t max7x7 = (1ULL << 49) - 1;
+
+  if (!arg || *arg == '\0') {
+    // No argument provided: use full range
+    args->grid7x7StartPattern = 0;
+    args->grid7x7EndPattern = max7x7;
+    args->gridSize = GRID_SIZE_7X7;
+    return true;
+  }
+
+  std::string str(arg);
+  size_t colonPos = str.find(':');
+
+  if (colonPos == std::string::npos) {
+    std::cerr << "[ERROR] Invalid 7x7 range format '" << arg << "', expected 'start:end', ':end', or 'start:'\n";
+    return false;
+  }
+
+  try {
+    std::string startStr = str.substr(0, colonPos);
+    std::string endStr = str.substr(colonPos + 1);
+
+    // Parse start value (default to 0 if empty)
+    if (startStr.empty()) {
+      args->grid7x7StartPattern = 0;
+    } else {
+      args->grid7x7StartPattern = std::stoull(startStr);
+      if (args->grid7x7StartPattern > max7x7) {
+        std::cerr << "[ERROR] Start pattern " << args->grid7x7StartPattern << " exceeds maximum 7x7 pattern (" << max7x7 << ")\n";
+        return false;
+      }
+    }
+
+    // Parse end value (default to max if empty)
+    if (endStr.empty()) {
+      args->grid7x7EndPattern = max7x7;
+    } else {
+      args->grid7x7EndPattern = std::stoull(endStr);
+      if (args->grid7x7EndPattern > max7x7) {
+        std::cerr << "[ERROR] End pattern " << args->grid7x7EndPattern << " exceeds maximum 7x7 pattern (" << max7x7 << ")\n";
+        return false;
+      }
+    }
+
+    // Validate range
+    if (args->grid7x7StartPattern >= args->grid7x7EndPattern) {
+      std::cerr << "[ERROR] Start pattern must be less than end pattern\n";
+      return false;
+    }
+
+    args->gridSize = GRID_SIZE_7X7;
+    return true;
+  } catch (const std::exception&) {
+    std::cerr << "[ERROR] Invalid 7x7 range format '" << arg << "', expected numeric values\n";
+    return false;
+  }
+}
+
 static error_t parseArgpOptions(int key, char* arg, struct argp_state* state) {
   ProgramArgs* a = (ProgramArgs*)state->input;
 
@@ -166,6 +231,11 @@ static error_t parseArgpOptions(int key, char* arg, struct argp_state* state) {
   case 'f':
     if (!parseFrameMode(arg, a)) {
       argp_failure(state, 1, 0, "Invalid frame mode");
+    }
+    break;
+  case '7':
+    if (!parse7x7Range(arg, a)) {
+      argp_failure(state, 1, 0, "Invalid 7x7 range specification");
     }
     break;
   case 'D':
@@ -256,7 +326,10 @@ void initializeDefaultArgs(ProgramArgs* args) {
   args->testApi = TEST_API_NONE;
   args->simulateType = SIMULATE_NONE;
   args->frameMode = FRAME_MODE_NONE;
+  args->gridSize = GRID_SIZE_8X8;
   args->frameModeIndex = 0;
+  args->grid7x7StartPattern = 0;
+  args->grid7x7EndPattern = (1ULL << 49) - 1;
   args->logFilePath = "";
   args->queueDirectory = "./request-queue";
   args->subgridCachePath = "";

--- a/find-optimal/src/explore-subgrid.cpp
+++ b/find-optimal/src/explore-subgrid.cpp
@@ -302,12 +302,12 @@ void analyzePattern(uint64_t pattern, SubgridStats& stats) {
   while (fastSearchGenerations < FAST_SEARCH_MAX_GENERATIONS) {
     // Step through 6 generations and check for termination/cycles
     fastSearchGenerations += 6;
-    uint64_t g2 = computeNextGeneration(g1);
-    uint64_t g3 = computeNextGeneration(g2);
-    uint64_t g4 = computeNextGeneration(g3);
-    uint64_t g5 = computeNextGeneration(g4);
-    uint64_t g6 = computeNextGeneration(g5);
-    g1 = computeNextGeneration(g6);
+    uint64_t g2 = computeNextGeneration8x8(g1);
+    uint64_t g3 = computeNextGeneration8x8(g2);
+    uint64_t g4 = computeNextGeneration8x8(g3);
+    uint64_t g5 = computeNextGeneration8x8(g4);
+    uint64_t g6 = computeNextGeneration8x8(g5);
+    g1 = computeNextGeneration8x8(g6);
 
     // After computing all 6 generations, check for coverability at each step
     // (only if we haven't found it yet)
@@ -340,7 +340,7 @@ void analyzePattern(uint64_t pattern, SubgridStats& stats) {
   }
 
   // Get accurate total generations using countGenerations
-  int totalGenerations = countGenerations(pattern);
+  int totalGenerations = countGenerations(pattern, computeNextGeneration8x8);
 
   stats.recordPattern(fastSearchGenerations, coverableAtGeneration, totalGenerations);
 }

--- a/find-optimal/src/explore-subgrid.cpp
+++ b/find-optimal/src/explore-subgrid.cpp
@@ -340,7 +340,7 @@ void analyzePattern(uint64_t pattern, SubgridStats& stats) {
   }
 
   // Get accurate total generations using countGenerations
-  int totalGenerations = countGenerations(pattern, computeNextGeneration8x8);
+  int totalGenerations = countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD);
 
   stats.recordPattern(fastSearchGenerations, coverableAtGeneration, totalGenerations);
 }

--- a/find-optimal/src/gol_cuda.cu
+++ b/find-optimal/src/gol_cuda.cu
@@ -74,6 +74,53 @@ __global__ void processCandidates(uint64_t *candidates, uint64_t *numCandidates,
   }
 }
 
+__global__ void processCandidates7x7(uint64_t *candidates, uint64_t *numCandidates, uint64_t *bestPattern,
+                                     uint64_t *bestGenerations, CycleDetectionAlgorithm algorithm) {
+  for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < *numCandidates; i += blockDim.x * gridDim.x) {
+    // Use 7x7 computation in compact format (computeNextGeneration7x7 handles pack/unpack internally)
+    uint64_t generations = countGenerations(candidates[i], computeNextGeneration7x7, algorithm);
+    if (generations > 0) {  // Only process if it actually ended
+      // Check to see if it's higher and emit it in best(Pattern|Generations)
+      uint64_t old = atomicMax((unsigned long long *)bestGenerations, (unsigned long long)generations);
+      if (old < generations) {
+        *bestPattern = candidates[i];  // Store compact 7x7 format
+      }
+    }
+  }
+}
+
+// 7x7 exhaustive search kernel
+// Divides all 2^49 patterns among threads, each processing a range
+__global__ void find7x7Candidates(uint64_t rangeStart, uint64_t rangeEnd,
+                                   uint64_t *candidates, uint64_t *numCandidates,
+                                   CycleDetectionAlgorithm algorithm) {
+  // Calculate which pattern range this thread is responsible for
+  uint64_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
+  uint64_t totalThreads = gridDim.x * blockDim.x;
+
+  uint64_t patternsPerThread = (rangeEnd - rangeStart + totalThreads - 1) / totalThreads;
+  uint64_t threadStart = rangeStart + (threadId * patternsPerThread);
+  uint64_t threadEnd = threadStart + patternsPerThread;
+
+  if (threadStart >= rangeEnd) return;
+  if (threadEnd > rangeEnd) threadEnd = rangeEnd;
+
+  // Process each 7x7 pattern in this thread's range
+  for (uint64_t pattern7x7 = threadStart; pattern7x7 < threadEnd; pattern7x7++) {
+    // Use 7x7 computation in compact format (computeNextGeneration7x7 handles pack/unpack internally)
+    int gens = countGenerations(pattern7x7, computeNextGeneration7x7, algorithm);
+
+    // Save patterns that reach minimum candidate threshold
+    // Store in compact 7x7 format to save memory
+    if (gens >= MIN_CANDIDATE_GENERATIONS) {
+      uint64_t idx = atomicAdd((unsigned long long*)numCandidates, 1ULL);
+      if (idx < FRAME_SEARCH_MAX_CANDIDATES) {
+        candidates[idx] = pattern7x7;  // Store compact format
+      }
+    }
+  }
+}
+
 __global__ void findCandidatesInKernel(uint64_t kernel, uint64_t *candidates, uint64_t *numCandidates) {
   uint64_t startingPattern = kernel;
   startingPattern += ((uint64_t)(threadIdx.x & 15)) << 10;  // set the lower row of 4 'T' bits
@@ -170,6 +217,85 @@ __host__ void executeKernelSearch(gol::SearchMemory &mem, ProgramArgs *cli, uint
 
     bool isFrameComplete = (kernelIdx == (1ULL << FRAME_SEARCH_NUM_K_BITS) - 1);
     reportKernelResults(mem, cli, startTime, frame, frameIdx, kernelIdx, isFrameComplete);
+  }
+}
+
+__host__ void execute7x7Search(gol::SearchMemory &mem, ProgramArgs *cli, uint64_t rangeStart, uint64_t rangeEnd) {
+  const double startTime = getHighResCurrentTime();
+
+  // Phase 1: Find candidates in this range
+  *mem.h_numCandidates() = 0;
+  cudaCheckError(cudaMemcpy(mem.d_numCandidates(), mem.h_numCandidates(), sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+  find7x7Candidates<<<FRAME_SEARCH_GRID_SIZE, FRAME_SEARCH_THREADS_PER_BLOCK>>>(
+      rangeStart, rangeEnd, mem.d_candidates(), mem.d_numCandidates(), cli->cycleDetection);
+
+  cudaCheckError(cudaGetLastError());
+  cudaCheckError(cudaDeviceSynchronize());
+  cudaCheckError(cudaMemcpy(mem.h_numCandidates(), mem.d_numCandidates(), sizeof(uint64_t), cudaMemcpyDeviceToHost));
+
+  // Phase 2: Process candidates if found (recount to find best)
+  *mem.h_bestGenerations() = 0;
+  *mem.h_bestPattern() = 0;
+
+  if (*mem.h_numCandidates() > 0) {
+    cudaCheckError(
+        cudaMemcpy(mem.d_bestGenerations(), mem.h_bestGenerations(), sizeof(uint64_t), cudaMemcpyHostToDevice));
+    cudaCheckError(cudaMemcpy(mem.d_bestPattern(), mem.h_bestPattern(), sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+    // Process 7x7 candidates
+    processCandidates7x7<<<FRAME_SEARCH_GRID_SIZE, FRAME_SEARCH_THREADS_PER_BLOCK>>>(
+        mem.d_candidates(), mem.d_numCandidates(), mem.d_bestPattern(), mem.d_bestGenerations(), cli->cycleDetection);
+
+    cudaCheckError(cudaGetLastError());
+    cudaCheckError(cudaDeviceSynchronize());
+
+    cudaCheckError(cudaMemcpy(mem.h_bestPattern(), mem.d_bestPattern(), sizeof(uint64_t), cudaMemcpyDeviceToHost));
+    cudaCheckError(
+        cudaMemcpy(mem.h_bestGenerations(), mem.d_bestGenerations(), sizeof(uint64_t), cudaMemcpyDeviceToHost));
+    updateBestGenerations(*mem.h_bestGenerations());
+  }
+
+  report7x7Results(mem, cli, startTime, rangeStart, rangeEnd);
+}
+
+__host__ void report7x7Results(gol::SearchMemory &mem, ProgramArgs *cli, double startTime,
+                                uint64_t rangeStart, uint64_t rangeEnd) {
+  const double searchTime = getHighResCurrentTime() - startTime;
+  const uint64_t totalPatterns = rangeEnd - rangeStart;
+  const uint64_t patternsPerSec = (searchTime > 0) ? (totalPatterns / searchTime) : 0;
+
+  // Calculate progress through entire 7x7 space
+  const uint64_t total7x7Patterns = (1ULL << 49);
+  double progress = (double)rangeEnd / total7x7Patterns * 100.0;
+
+  if (*mem.h_numCandidates() > 0) {
+    char bestPatternBin[BINARY_STRING_BUFFER_SIZE] = {'\0'};
+    asBinary(*mem.h_bestPattern(), bestPatternBin, 49);
+
+    Logger::out() << "timestamp=" << time(NULL)
+                   << ", rangeStart=" << rangeStart
+                   << ", rangeEnd=" << rangeEnd
+                   << ", bestGenerations=" << (int)*mem.h_bestGenerations()
+                   << ", bestPattern=" << *mem.h_bestPattern()
+                   << ", bestPatternBin=" << bestPatternBin
+                   << ", patternsPerSec=" << formatWithCommas(patternsPerSec)
+                   << ", progress=" << std::fixed << std::setprecision(2) << progress << "%\n";
+
+    if (!cli->dontSaveResults) {
+      queueGoogleSummaryData((int)*mem.h_bestGenerations(), *mem.h_bestPattern(), bestPatternBin, UINT64_MAX);
+
+      if ((int)*mem.h_bestGenerations() >= 200) {
+        queueGoogleProgress(0, 0, (int)*mem.h_bestGenerations(), *mem.h_bestPattern(), bestPatternBin);
+      }
+    }
+  } else {
+    Logger::out() << "timestamp=" << time(NULL)
+                   << ", rangeStart=" << rangeStart
+                   << ", rangeEnd=" << rangeEnd
+                   << ", candidates=0"
+                   << ", patternsPerSec=" << formatWithCommas(patternsPerSec)
+                   << ", progress=" << std::fixed << std::setprecision(2) << progress << "%\n";
   }
 }
 

--- a/find-optimal/src/gol_cuda.cu
+++ b/find-optimal/src/gol_cuda.cu
@@ -49,7 +49,7 @@ __global__ void findSubgridCandidates(uint64_t rangeStart, uint64_t rangeEnd,
       uint64_t pattern8x8 = expand7x7To8x8(pattern7x7, rowOffset, colOffset);
 
       // Count generations for this 8x8 pattern
-      int gens = countGenerations(pattern8x8, algorithm);
+      int gens = countGenerations(pattern8x8, computeNextGeneration8x8, algorithm);
 
       // Save each 8x8 pattern that meets the threshold
       if (gens >= minGenerations) {
@@ -63,7 +63,7 @@ __global__ void findSubgridCandidates(uint64_t rangeStart, uint64_t rangeEnd,
 __global__ void processCandidates(uint64_t *candidates, uint64_t *numCandidates, uint64_t *bestPattern,
                                   uint64_t *bestGenerations, CycleDetectionAlgorithm algorithm) {
   for (uint64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < *numCandidates; i += blockDim.x * gridDim.x) {
-    uint64_t generations = countGenerations(candidates[i], algorithm);
+    uint64_t generations = countGenerations(candidates[i], computeNextGeneration8x8, algorithm);
     if (generations > 0) {  // Only process if it actually ended
       // Check to see if it's higher and emit it in best(Pattern|Generations)
       uint64_t old = atomicMax((unsigned long long *)bestGenerations, (unsigned long long)generations);

--- a/find-optimal/src/gol_search.cpp
+++ b/find-optimal/src/gol_search.cpp
@@ -9,23 +9,29 @@
 #include "logging.h"
 
 int executeMainSearch(ProgramArgs* cli) {
-  // Initialize global best generations from Google Sheets database
-  int dbBestGenerations = getGoogleBestResult();
-  if (dbBestGenerations > 0) {
-    gBestGenerations = dbBestGenerations;
-    Logger::out() << "Best generations so far: " << gBestGenerations << "\n";
-  }
+  // Only query Google Sheets if we're saving results
+  if (!cli->dontSaveResults) {
+    // Initialize global best generations from Google Sheets database
+    int dbBestGenerations = getGoogleBestResult();
+    if (dbBestGenerations > 0) {
+      gBestGenerations = dbBestGenerations;
+      Logger::out() << "Best generations so far: " << gBestGenerations << "\n";
+    }
 
-  // Initialize frame completion cache (only useful for random/sequential modes, not index mode)
-  if (cli->frameMode != FRAME_MODE_INDEX && loadGoogleFrameCache()) {
-    uint64_t completedFrames = getGoogleFrameCacheCompletedCount();
-    Logger::out() << "Frame completion cache initialized with " << completedFrames << " completed frames\n";
+    // Initialize frame completion cache for 8x8 search (only useful for random/sequential modes, not index mode)
+    // 7x7 doesn't use frame cache since it's exhaustive search
+    if (cli->gridSize == GRID_SIZE_8X8 && cli->frameMode != FRAME_MODE_INDEX && loadGoogleFrameCache()) {
+      uint64_t completedFrames = getGoogleFrameCacheCompletedCount();
+      Logger::out() << "Frame completion cache initialized with " << completedFrames << " completed frames\n";
+    }
   }
 
   search(cli);
 
-  // Wait for any async upload threads to complete
-  std::this_thread::sleep_for(std::chrono::seconds(10));
+  // Wait for any async upload threads to complete (only if we're saving results)
+  if (!cli->dontSaveResults) {
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+  }
 
   return 0;
 }

--- a/find-optimal/src/simulation_handlers.cpp
+++ b/find-optimal/src/simulation_handlers.cpp
@@ -75,7 +75,7 @@ int handlePatternSimulation(ProgramArgs* cli) {
 
       // ENTER (empty string) or 'n'/'N' means continue
       if (stepInputStr.empty() || stepInputStr[0] == 'n' || stepInputStr[0] == 'N') {
-        uint64_t nextPattern = computeNextGeneration(currentPattern);
+        uint64_t nextPattern = computeNextGeneration8x8(currentPattern);
 
         // Check if pattern died out
         if (nextPattern == 0) {

--- a/find-optimal/src/simulation_handlers.cpp
+++ b/find-optimal/src/simulation_handlers.cpp
@@ -67,17 +67,18 @@ int handlePatternSimulation(ProgramArgs* cli) {
 
     std::cout << "Starting pattern: " << currentPattern << "\n\n";
 
-    // For 7x7: keep in compact format (computeNextGeneration7x7 handles pack/unpack internally)
+    // For 7x7: unpack at start, keep in unpacked format during simulation, display uses compact
     // For 8x8: already in correct format
-    uint64_t simulationPattern = currentPattern;
+    uint64_t simulationPattern = is7x7 ? unpack7x7(currentPattern) : currentPattern;
+    uint64_t displayPattern = currentPattern;  // Keep compact version for display
 
     // Simulate the pattern
     int generation = 0;
 
     while (true) {
       std::cout << "Generation " << generation << ":\n";
-      // Pattern is already in display format (compact for 7x7, normal for 8x8)
-      printPattern(simulationPattern, is7x7 ? 7 : 8);
+      // Display compact format for 7x7, normal format for 8x8
+      printPattern(displayPattern, is7x7 ? 7 : 8);
 
       std::cout << "Press ENTER/'n' to continue, 'q' to quit simulation: ";
 
@@ -94,8 +95,13 @@ int handlePatternSimulation(ProgramArgs* cli) {
       // ENTER (empty string) or 'n'/'N' means continue
       if (stepInputStr.empty() || stepInputStr[0] == 'n' || stepInputStr[0] == 'N') {
         // Use appropriate computation based on grid size
-        // computeNextGeneration7x7 handles pack/unpack internally (input/output both compact)
+        // For 7x7: work on unpacked format, pack only for display
         uint64_t nextPattern = is7x7 ? computeNextGeneration7x7(simulationPattern) : computeNextGeneration8x8(simulationPattern);
+        if (is7x7) {
+          displayPattern = pack7x7(nextPattern);
+        } else {
+          displayPattern = nextPattern;
+        }
 
         // Check if pattern died out
         if (nextPattern == 0) {

--- a/find-optimal/tests/test_gol_core.cpp
+++ b/find-optimal/tests/test_gol_core.cpp
@@ -23,14 +23,14 @@ class GOLComputationTest : public ::testing::Test {
 TEST_F(GOLComputationTest, ComputeNextGenerationEmpty) {
   // Empty grid should stay empty
   uint64_t empty = 0;
-  uint64_t next = computeNextGeneration(empty);
+  uint64_t next = computeNextGeneration8x8(empty);
   EXPECT_EQ(next, 0);
 }
 
 TEST_F(GOLComputationTest, ComputeNextGenerationSingleCell) {
   // Single cell should die (underpopulation)
   uint64_t single = 1ULL << (4 * 8 + 4);  // Center cell
-  uint64_t next = computeNextGeneration(single);
+  uint64_t next = computeNextGeneration8x8(single);
   EXPECT_EQ(next, 0);
 }
 
@@ -50,7 +50,7 @@ TEST_F(GOLComputationTest, ComputeNextGenerationBlock) {
   // clang-format on
 
   uint64_t pattern = createPattern(block);
-  uint64_t next = computeNextGeneration(pattern);
+  uint64_t next = computeNextGeneration8x8(pattern);
 
   // Should remain unchanged
   EXPECT_EQ(next, pattern);
@@ -85,7 +85,7 @@ TEST_F(GOLComputationTest, ComputeNextGenerationBlinker) {
   // clang-format on
 
   uint64_t vertical = createPattern(verticalBlinker);
-  uint64_t next = computeNextGeneration(vertical);
+  uint64_t next = computeNextGeneration8x8(vertical);
 
   verifyPattern(next, horizontalBlinker);
 }
@@ -119,7 +119,7 @@ TEST_F(GOLComputationTest, ComputeNextGenerationGlider) {
   // clang-format on
 
   uint64_t pattern = createPattern(glider);
-  uint64_t next = computeNextGeneration(pattern);
+  uint64_t next = computeNextGeneration8x8(pattern);
 
   verifyPattern(next, gliderNext);
 }
@@ -140,7 +140,7 @@ TEST_F(GOLComputationTest, ComputeNextGenerationBeehive) {
   // clang-format on
 
   uint64_t pattern = createPattern(beehive);
-  uint64_t next = computeNextGeneration(pattern);
+  uint64_t next = computeNextGeneration8x8(pattern);
 
   // Should remain unchanged
   EXPECT_EQ(next, pattern);
@@ -150,12 +150,12 @@ TEST_F(GOLComputationTest, ComputeNextGenerationBoundaryConditions) {
   // Test that cells at edges are treated as having dead neighbors
   // Single cell at corner should die
   uint64_t corner = 1ULL << (0 * 8 + 0);  // Top-left corner
-  uint64_t next = computeNextGeneration(corner);
+  uint64_t next = computeNextGeneration8x8(corner);
   EXPECT_EQ(next, 0);
 
   // Single cell at edge should die
   uint64_t edge = 1ULL << (0 * 8 + 4);  // Top edge
-  next = computeNextGeneration(edge);
+  next = computeNextGeneration8x8(edge);
   EXPECT_EQ(next, 0);
 }
 
@@ -188,7 +188,7 @@ TEST_F(GOLComputationTest, ComputeNextGenerationOvercrowding) {
   };
   // clang-format on
   uint64_t pattern = createPattern(overcrowded);
-  uint64_t next = computeNextGeneration(pattern);
+  uint64_t next = computeNextGeneration8x8(pattern);
 
   verifyPattern(next, overcrowdedNext);
 }
@@ -222,7 +222,7 @@ TEST_F(GOLComputationTest, ComputeNextGenerationBirth) {
   // clang-format on
 
   uint64_t pattern = createPattern(birthSetup);
-  uint64_t next = computeNextGeneration(pattern);
+  uint64_t next = computeNextGeneration8x8(pattern);
 
   verifyPattern(next, afterBirth);
 }
@@ -327,7 +327,7 @@ class GOLLifecycleTest : public GOLComputationTest {
 TEST_F(GOLLifecycleTest, CountGenerationsSingleCell) {
   // Single cell dies from underpopulation - dies at generation 2, so countGenerations returns 1
   uint64_t single = 1ULL << (4 * 8 + 4);  // Center cell
-  EXPECT_EQ(countGenerations(single), 1);
+  EXPECT_EQ(countGenerations(single, computeNextGeneration8x8), 1);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsBlock) {
@@ -345,7 +345,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsBlock) {
   };
   // clang-format on
   uint64_t pattern = createPattern(block);
-  EXPECT_EQ(countGenerations(pattern), 0);  // Still life = infinite
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 0);  // Still life = infinite
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsBlinker) {
@@ -363,7 +363,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsBlinker) {
   };
   // clang-format on
   uint64_t pattern = createPattern(blinker);
-  EXPECT_EQ(countGenerations(pattern), 0);  // Oscillator = infinite
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 0);  // Oscillator = infinite
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsRPentomino) {
@@ -382,7 +382,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsRPentomino) {
   };
   // clang-format on
   uint64_t pattern = createPattern(rpentomino);
-  int generations = countGenerations(pattern);
+  int generations = countGenerations(pattern, computeNextGeneration8x8);
   // R-pentomino typically stabilizes or becomes periodic
   // Should either return 0 (stable/periodic) or a positive number if it dies
   EXPECT_TRUE(generations >= 0);
@@ -404,7 +404,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsSimpleDieout) {
   };
   // clang-format on
   uint64_t pattern = createPattern(line);
-  int generations = countGenerations(pattern);
+  int generations = countGenerations(pattern, computeNextGeneration8x8);
   EXPECT_GT(generations, 0);   // Should die out
   EXPECT_LT(generations, 10);  // But quickly
 }
@@ -424,7 +424,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsBeehive) {
   };
   // clang-format on
   uint64_t pattern = createPattern(beehive);
-  EXPECT_EQ(countGenerations(pattern), 0);  // Still life = infinite
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 0);  // Still life = infinite
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsGlider) {
@@ -443,7 +443,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsGlider) {
   };
   // clang-format on
   uint64_t pattern = createPattern(glider);
-  int generations = countGenerations(pattern);
+  int generations = countGenerations(pattern, computeNextGeneration8x8);
   // In bounded grid, glider will either stabilize, become periodic, or die
   EXPECT_TRUE(generations >= 0);
 }
@@ -453,49 +453,49 @@ TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern212) {
   // Pattern that runs for exactly 212 generations
   // 1000001111101001000000000111101011000000110001001111000110110011
   uint64_t pattern = 9505129015762284979ULL;
-  EXPECT_EQ(countGenerations(pattern), 212);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 212);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern209a) {
   // Pattern that runs for exactly 209 generations
   // 0111000001011100100001100001010011111010110101100010000101110100
   uint64_t pattern = 8096493654771114356ULL;
-  EXPECT_EQ(countGenerations(pattern), 209);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 209);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern209b) {
   // Another pattern that runs for exactly 209 generations
   // 1000000010010011100101000010001110000010011011011000111111001010
   uint64_t pattern = 9264911738664226762ULL;
-  EXPECT_EQ(countGenerations(pattern), 209);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 209);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern205) {
   // Pattern that runs for exactly 205 generations
   // 0101111010010001101011001010010110011101110001000011100100010101
   uint64_t pattern = 6814417538504734997ULL;
-  EXPECT_EQ(countGenerations(pattern), 205);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 205);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern199) {
   // Pattern that runs for exactly 199 generations
   // 0011100100111010001001000101011011000001000110100001100110001010
   uint64_t pattern = 4123648363836610954ULL;
-  EXPECT_EQ(countGenerations(pattern), 199);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 199);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern197) {
   // Pattern that runs for exactly 197 generations
   // 0000000100100101011100011110000110110010101101001010100111010011
   uint64_t pattern = 82597382355986899ULL;
-  EXPECT_EQ(countGenerations(pattern), 197);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 197);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern193) {
   // Pattern that runs for exactly 193 generations
   // 1010110110011101001110101101100100001001010101010011011001000100
   uint64_t pattern = 12510220043743999556ULL;
-  EXPECT_EQ(countGenerations(pattern), 193);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 193);
 }
 
 // Test step6GenerationsAndCheck function - critical CUDA kernel logic
@@ -771,6 +771,6 @@ TEST(GOLKernelTest, ConstructKernelBitPositions) {
 TEST_F(GOLComputationTest, CountGenerations_EmptyPattern) {
   // Empty pattern (all zeros) should return 0 generations
   uint64_t empty = 0;
-  int gens = countGenerations(empty, CYCLE_DETECTION_FLOYD);
+  int gens = countGenerations(empty, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD);
   EXPECT_EQ(gens, 0) << "Empty pattern should have 0 generations";
 }

--- a/find-optimal/tests/test_gol_core.cpp
+++ b/find-optimal/tests/test_gol_core.cpp
@@ -327,7 +327,7 @@ class GOLLifecycleTest : public GOLComputationTest {
 TEST_F(GOLLifecycleTest, CountGenerationsSingleCell) {
   // Single cell dies from underpopulation - dies at generation 2, so countGenerations returns 1
   uint64_t single = 1ULL << (4 * 8 + 4);  // Center cell
-  EXPECT_EQ(countGenerations(single, computeNextGeneration8x8), 1);
+  EXPECT_EQ(countGenerations(single, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 1);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsBlock) {
@@ -345,7 +345,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsBlock) {
   };
   // clang-format on
   uint64_t pattern = createPattern(block);
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 0);  // Still life = infinite
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 0);  // Still life = infinite
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsBlinker) {
@@ -363,7 +363,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsBlinker) {
   };
   // clang-format on
   uint64_t pattern = createPattern(blinker);
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 0);  // Oscillator = infinite
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 0);  // Oscillator = infinite
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsRPentomino) {
@@ -382,7 +382,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsRPentomino) {
   };
   // clang-format on
   uint64_t pattern = createPattern(rpentomino);
-  int generations = countGenerations(pattern, computeNextGeneration8x8);
+  int generations = countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD);
   // R-pentomino typically stabilizes or becomes periodic
   // Should either return 0 (stable/periodic) or a positive number if it dies
   EXPECT_TRUE(generations >= 0);
@@ -404,7 +404,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsSimpleDieout) {
   };
   // clang-format on
   uint64_t pattern = createPattern(line);
-  int generations = countGenerations(pattern, computeNextGeneration8x8);
+  int generations = countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD);
   EXPECT_GT(generations, 0);   // Should die out
   EXPECT_LT(generations, 10);  // But quickly
 }
@@ -424,7 +424,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsBeehive) {
   };
   // clang-format on
   uint64_t pattern = createPattern(beehive);
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 0);  // Still life = infinite
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 0);  // Still life = infinite
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsGlider) {
@@ -443,7 +443,7 @@ TEST_F(GOLLifecycleTest, CountGenerationsGlider) {
   };
   // clang-format on
   uint64_t pattern = createPattern(glider);
-  int generations = countGenerations(pattern, computeNextGeneration8x8);
+  int generations = countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD);
   // In bounded grid, glider will either stabilize, become periodic, or die
   EXPECT_TRUE(generations >= 0);
 }
@@ -453,49 +453,49 @@ TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern212) {
   // Pattern that runs for exactly 212 generations
   // 1000001111101001000000000111101011000000110001001111000110110011
   uint64_t pattern = 9505129015762284979ULL;
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 212);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 212);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern209a) {
   // Pattern that runs for exactly 209 generations
   // 0111000001011100100001100001010011111010110101100010000101110100
   uint64_t pattern = 8096493654771114356ULL;
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 209);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 209);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern209b) {
   // Another pattern that runs for exactly 209 generations
   // 1000000010010011100101000010001110000010011011011000111111001010
   uint64_t pattern = 9264911738664226762ULL;
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 209);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 209);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern205) {
   // Pattern that runs for exactly 205 generations
   // 0101111010010001101011001010010110011101110001000011100100010101
   uint64_t pattern = 6814417538504734997ULL;
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 205);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 205);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern199) {
   // Pattern that runs for exactly 199 generations
   // 0011100100111010001001000101011011000001000110100001100110001010
   uint64_t pattern = 4123648363836610954ULL;
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 199);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 199);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern197) {
   // Pattern that runs for exactly 197 generations
   // 0000000100100101011100011110000110110010101101001010100111010011
   uint64_t pattern = 82597382355986899ULL;
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 197);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 197);
 }
 
 TEST_F(GOLLifecycleTest, CountGenerationsKnownPattern193) {
   // Pattern that runs for exactly 193 generations
   // 1010110110011101001110101101100100001001010101010011011001000100
   uint64_t pattern = 12510220043743999556ULL;
-  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8), 193);
+  EXPECT_EQ(countGenerations(pattern, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD), 193);
 }
 
 // Test step6GenerationsAndCheck function - critical CUDA kernel logic

--- a/find-optimal/tests/test_subgrid_cache.cpp
+++ b/find-optimal/tests/test_subgrid_cache.cpp
@@ -387,7 +387,7 @@ void findSubgridCandidatesCPU(uint64_t rangeStart, uint64_t rangeEnd,
       uint64_t pattern8x8 = expand7x7To8x8(pattern7x7, rowOffset, colOffset);
 
       // Count generations for this 8x8 pattern
-      int gens = countGenerations(pattern8x8, algorithm);
+      int gens = countGenerations(pattern8x8, computeNextGeneration8x8, algorithm);
 
       // Save each 8x8 pattern that meets the threshold
       if (gens >= minGenerations) {
@@ -553,7 +553,7 @@ TEST_F(SubgridCacheTest, FindSubgridCandidates_ExactPatternVerification) {
         if (entry.pattern == expected) {
           foundMatch = true;
           // Verify generation count matches
-          int expectedGens = countGenerations(expected, CYCLE_DETECTION_FLOYD);
+          int expectedGens = countGenerations(expected, computeNextGeneration8x8, CYCLE_DETECTION_FLOYD);
           EXPECT_EQ(entry.generations, expectedGens)
               << "Generation count mismatch for pattern " << pattern7x7
               << " at position " << pos;

--- a/patterns/217-gen-torus.rle
+++ b/patterns/217-gen-torus.rle
@@ -1,0 +1,3 @@
+#CXRLE Pos=-3,-3
+x = 7, y = 6, rule = B3/S23:T7,7
+o5bo$2b2ob2o$b5o$b2ob2o$3b2obo$4o!

--- a/patterns/222-gen-torus.rle
+++ b/patterns/222-gen-torus.rle
@@ -1,0 +1,2 @@
+x = 7, y = 7, rule = B3/S23:T7,7
+4b3o$obob2o$o3bo$2bob2o$2o3bo$2b2o2bo!

--- a/patterns/223-gen-torus-a.rle
+++ b/patterns/223-gen-torus-a.rle
@@ -1,0 +1,2 @@
+x = 7, y = 7, rule = B3/S23:T7,7
+2bob3o$3o$o2b2obo$2b3o$2o$o2bobo$bo2bobo!

--- a/patterns/223-gen-torus-b.rle
+++ b/patterns/223-gen-torus-b.rle
@@ -1,0 +1,2 @@
+x = 7, y = 7, rule = B3/S23:T7,7
+2bob2o$2o2b2o$obo$2o3bo$2b2ob2o$bobo2bo$o3bobo!

--- a/patterns/223-gen-torus-c.rle
+++ b/patterns/223-gen-torus-c.rle
@@ -1,0 +1,2 @@
+x = 7, y = 7, rule = B3/S23:T7,7
+2bob3o$bo2bobo$o2bobo$2o$2b3o$o2b2obo$3o!

--- a/tools/pattern-converter
+++ b/tools/pattern-converter
@@ -3,13 +3,22 @@ import argparse
 import os
 import sys
 
-HEADER = [
-    "#CXRLE Pos=-4,-4",
-    "x = 8, y = 8, rule = B3/S23:P8,8"
-]
+def get_header(grid_size, topology):
+    """Generate appropriate RLE header based on grid size and topology."""
+    if grid_size == 7:
+        width, height = 7, 7
+    else:  # 8x8
+        width, height = 8, 8
 
-def rle_to_bin(rle_lines):
-    """Convert RLE body (list of row strings) into a flattened 64-bit binary string."""
+    # P for plane (non-wrapping), T for torus (wrapping)
+    topo = "T" if topology == "torus" else "P"
+
+    return [
+        f"x = {width}, y = {height}, rule = B3/S23:{topo}{width},{height}"
+    ]
+
+def rle_to_bin(rle_lines, grid_size):
+    """Convert RLE body (list of row strings) into a flattened binary string."""
     rows = []
     for line in rle_lines:
         row = []
@@ -36,19 +45,41 @@ def rle_to_bin(rle_lines):
                 i += 1
             else:
                 i += 1
-        # pad/truncate to width 8
-        row = (row + ['0'] * 8)[:8]
+        # pad/truncate to width
+        row = (row + ['0'] * grid_size)[:grid_size]
         rows.append("".join(row))
-    # pad/truncate to exactly 8 rows
-    rows = (rows + ["0"*8]*8)[:8]
+
+    # pad/truncate to exactly grid_size rows
+    rows = (rows + ["0" * grid_size] * grid_size)[:grid_size]
+
+    # Return row-major binary string
     return "".join(rows)
 
-def bin_to_rle(binstring):
-    """Convert a 64-bit binary string (8x8) into compact RLE (no trailing 'b' on rows)."""
-    if len(binstring) != 64 or any(c not in '01' for c in binstring):
-        raise ValueError("Binary string must be exactly 64 characters of 0/1 (8x8).")
+def bin_to_rle(binstring, grid_size):
+    """Convert a binary string into compact RLE (no trailing 'b' on rows)."""
+    expected_bits = grid_size * grid_size
+    if len(binstring) != expected_bits or any(c not in '01' for c in binstring):
+        raise ValueError(f"Binary string must be exactly {expected_bits} characters of 0/1 ({grid_size}x{grid_size}).")
 
-    rows = [binstring[i*8:(i+1)*8] for i in range(8)]
+    # The C++ asBinary() outputs MSB-first
+    # For 7x7: bit 48 is at string index 0, bit 0 is at string index 48
+    # Bit layout: row0[bits 0-6] row1[bits 7-13] ... row6[bits 42-48]
+    # C++ outputs: [bit48...bit42][bit41...bit35]...[bit6...bit0]
+    # Which is: [row6_reversed][row5_reversed]...[row0_reversed]
+
+    # First reverse entire string to get rows in correct order
+    binstring = binstring[::-1]
+    # Now we have: [row0_reversed][row1_reversed]...[row6_reversed]
+
+    # Split into rows and reverse each row to get correct bit order within each row
+    rows = []
+    for i in range(grid_size):
+        row = binstring[i*grid_size:(i+1)*grid_size]
+        rows.append(row[::-1])  # Reverse each row to get correct left-to-right order
+
+    # Reverse the rows list so row0 comes first in the RLE output
+    rows.reverse()
+
     rle_rows = []
     for row in rows:
         # Trim trailing zeros so we don't emit trailing 'b' runs
@@ -73,15 +104,31 @@ def bin_to_rle(binstring):
             i = j
         rle_rows.append("".join(out))
 
+    # Remove leading empty rows (blank rows at the start)
+    while rle_rows and rle_rows[0] == "":
+        rle_rows.pop(0)
+
+    # Remove trailing empty rows to avoid ending with $!
+    while rle_rows and rle_rows[-1] == "":
+        rle_rows.pop()
+
     return "$".join(rle_rows) + "!"
 
 def main():
-    parser = argparse.ArgumentParser(description="Convert between RLE files, binary strings, and integers (8x8).")
+    parser = argparse.ArgumentParser(description="Convert between RLE files, binary strings, and integers.")
     parser.add_argument("-i", "--input", help="Path to RLE file to read")
     parser.add_argument("-o", "--output", help="Path to RLE file to write")
-    parser.add_argument("-b", "--binary", help="64-character binary string (0s and 1s)")
-    parser.add_argument("-p", "--pattern", help="64-bit integer pattern value")
+    parser.add_argument("-b", "--binary", help="Binary string (49 chars for 7x7, 64 chars for 8x8)")
+    parser.add_argument("-p", "--pattern", help="Integer pattern value")
+    parser.add_argument("-g", "--grid-size", type=int, choices=[7, 8], default=8,
+                        help="Grid size: 7 for 7x7, 8 for 8x8 (default: 8)")
+    parser.add_argument("-t", "--topology", choices=["plane", "torus"], default="plane",
+                        help="Topology: plane (non-wrapping) or torus (wrapping) (default: plane)")
     args = parser.parse_args()
+
+    grid_size = args.grid_size
+    expected_bits = grid_size * grid_size
+    max_value = 2**expected_bits - 1
 
     binstring = None
 
@@ -104,7 +151,7 @@ def main():
         # Collapse to rows by splitting on '$' (ignore trailing '!')
         rle_str = "".join(body_lines).replace("!", "")
         rle_rows = rle_str.split("$") if rle_str else []
-        binstring = rle_to_bin(rle_rows)
+        binstring = rle_to_bin(rle_rows, grid_size)
 
         # Show both formats
         pattern_int = int(binstring, 2)
@@ -114,16 +161,16 @@ def main():
     elif args.pattern:
         # Integer → binary string
         pattern_int = int(args.pattern)
-        if pattern_int < 0 or pattern_int >= 2**64:
-            print(f"Error: pattern must be a 64-bit unsigned integer (0 to {2**64-1})", file=sys.stderr)
+        if pattern_int < 0 or pattern_int > max_value:
+            print(f"Error: pattern must be a {expected_bits}-bit unsigned integer (0 to {max_value})", file=sys.stderr)
             sys.exit(1)
-        binstring = format(pattern_int, '064b')
+        binstring = format(pattern_int, f'0{expected_bits}b')
         print(f"Binary: {binstring}")
 
     elif args.binary:
         # Binary string → integer
-        if len(args.binary) != 64 or any(c not in '01' for c in args.binary):
-            print("Error: binary string must be exactly 64 characters of 0/1", file=sys.stderr)
+        if len(args.binary) != expected_bits or any(c not in '01' for c in args.binary):
+            print(f"Error: binary string must be exactly {expected_bits} characters of 0/1 for {grid_size}x{grid_size} grid", file=sys.stderr)
             sys.exit(1)
         binstring = args.binary
         pattern_int = int(binstring, 2)
@@ -136,9 +183,10 @@ def main():
 
     # Write output RLE file if requested
     if args.output and binstring:
-        rle_body = bin_to_rle(binstring)
+        rle_body = bin_to_rle(binstring, grid_size)
+        header = get_header(grid_size, args.topology)
         with open(args.output, "w") as f:
-            f.write("\n".join(HEADER) + "\n")
+            f.write("\n".join(header) + "\n")
             f.write(rle_body + "\n")
         print(f"Wrote RLE file to {args.output}")
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces 7x7 grid simulation and exhaustive search (CPU/CUDA), refactors evolution to templated 8x8/7x7 functions, adds CLI/simulator/tooling support, and updates tests/patterns.
> 
> - **Core/Algorithms**:
>   - Refactor evolution into generic template; add `computeNextGeneration8x8` and `computeNextGeneration7x7` with 7x7 (pack/unpack) helpers and masks; unify cycle detection via templates.
>   - Add 7x7 coverage masks/constants and reuse in `isCoverableBy7x7` and stepping logic.
> - **CUDA**:
>   - Add 7x7 kernels: `find7x7Candidates` and `processCandidates7x7`; host flows `execute7x7Search` and `report7x7Results` with batching and progress.
>   - Switch kernel generation counting to templated `countGenerations(..., computeNextGeneration8x8)`.
> - **Search Flow**:
>   - Split search path by `gridSize`; implement worker partitioning and batched ranges for 7x7; retain frame-based 8x8 path.
>   - Gate Google Sheets I/O when `dontSaveResults` is set; only init frame cache for 8x8.
> - **CLI/Simulation**:
>   - New options: `-7/--7x7-mode` with `start:end` range; `--simulate pattern:7x7` and `gridSize` handling; defaults set.
> - **Display/Utils**:
>   - Generalize `asBinary(numBits)` and `printPattern(gridSize)` for 7x7/8x8.
> - **Tests**:
>   - Update unit tests to use `computeNextGeneration8x8` and templated `countGenerations`; add validations for subgrid utilities.
> - **Tools/Patterns**:
>   - Enhance `tools/pattern-converter` for 7x7/8x8 and plane/torus headers.
>   - Add 7x7 torus RLE pattern files in `patterns/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6cf26e5497e3287dc325acf7b213a64b6a4a74b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->